### PR TITLE
fix default export

### DIFF
--- a/src/__tests__/SpectrumGenerator.js
+++ b/src/__tests__/SpectrumGenerator.js
@@ -1,4 +1,4 @@
-import SpectrumGenerator from '..';
+import { SpectrumGenerator } from '..';
 
 describe('SpectrumGenerator', () => {
   it('0 half peak', () => {
@@ -55,7 +55,7 @@ describe('SpectrumGenerator', () => {
       start: 0,
       end: 2,
       pointsPerUnit: 10,
-      peakWidthFct: (x) => 1 + 3 * x / 1000
+      peakWidthFct: (x) => 1 + (3 * x) / 1000
     });
 
     generator.addPeak([1, 1]);

--- a/src/__tests__/errors.js
+++ b/src/__tests__/errors.js
@@ -1,4 +1,4 @@
-import SpectrumGenerator from '..';
+import { SpectrumGenerator } from '..';
 
 const integerReg = /^\w+ option must be an integer$/;
 const endStartReg = /^end option must be larger than start$/;
@@ -14,13 +14,23 @@ describe('errors', () => {
     expect(() => new SpectrumGenerator({ end: 0.5 })).toThrow(integerReg);
     expect(() => new SpectrumGenerator({ end: false })).toThrow(integerReg);
 
-    expect(() => new SpectrumGenerator({ pointsPerUnit: 0.5 })).toThrow(integerReg);
-    expect(() => new SpectrumGenerator({ pointsPerUnit: false })).toThrow(integerReg);
+    expect(() => new SpectrumGenerator({ pointsPerUnit: 0.5 })).toThrow(
+      integerReg
+    );
+    expect(() => new SpectrumGenerator({ pointsPerUnit: false })).toThrow(
+      integerReg
+    );
 
-    expect(() => new SpectrumGenerator({ start: 0, end: 0 })).toThrow(endStartReg);
-    expect(() => new SpectrumGenerator({ start: 0, end: -10 })).toThrow(endStartReg);
+    expect(() => new SpectrumGenerator({ start: 0, end: 0 })).toThrow(
+      endStartReg
+    );
+    expect(() => new SpectrumGenerator({ start: 0, end: -10 })).toThrow(
+      endStartReg
+    );
 
-    expect(() => new SpectrumGenerator({ peakWidthFct: null })).toThrow(peakWidthReg);
+    expect(() => new SpectrumGenerator({ peakWidthFct: null })).toThrow(
+      peakWidthReg
+    );
   });
 
   it('addPeaks not an array', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ for (let i = 0; i <= gaussianWidth * gaussianFactor; i++) {
 }
 
 
-export default class SpectrumGenerator {
+export class SpectrumGenerator {
   /**
      * @class SpectrumGenerator
      * @constructor


### PR DESCRIPTION
  @targos 

I tried to fix it as you did but the build is not passing. I should not use to try `cheminfo build` ?

```
Entry module not found: Error: Can't resolve '/home/lpatiny/git/cheminfo/spectrum-generator/lib/index.js' in '/home/lpatiny/git/cheminfo/spectrum-generator'
resolve '/home/lpatiny/git/cheminfo/spectrum-generator/lib/index.js' in '/home/lpatiny/git/cheminfo/spectrum-generator'
  using description file: /home/lpatiny/git/cheminfo/spectrum-generator/package.json (relative path: .)
    Field 'browser' doesn't contain a valid alias configuration
```